### PR TITLE
[PD-10133] Make Zoom MeetingStatus property non nullable

### DIFF
--- a/Source/ZoomNet/Models/Meeting.cs
+++ b/Source/ZoomNet/Models/Meeting.cs
@@ -66,7 +66,7 @@ namespace ZoomNet.Models
 		/// The status.
 		/// </value>
 		[JsonPropertyName("status")]
-		public MeetingStatus? Status { get; set; }
+		public MeetingStatus Status { get; set; }
 
 		/// <summary>
 		/// Gets or sets the meeting description.

--- a/Source/ZoomNet/ZoomNet.csproj
+++ b/Source/ZoomNet/ZoomNet.csproj
@@ -19,7 +19,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Version>1.0.1</Version>
+    <Version>1.0.2</Version>
     <PackageId>PowerDiary.ZoomNet</PackageId>
     <Authors>Jeremie Desautels;PowerDiary</Authors>
     <Company>PowerDiary</Company>
@@ -29,7 +29,7 @@
     <RepositoryUrl>https://github.com/powerdiary/ZoomNet</RepositoryUrl>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <PackageTags>ZoomNet zoom meeting webinar</PackageTags>
-    <PackageReleaseNotes>1.0.1</PackageReleaseNotes>
+    <PackageReleaseNotes>1.0.2</PackageReleaseNotes>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This property is described in the [Zoom documentation](https://developers.zoom.us/docs/api/rest/reference/zoom-api/methods/#operation/meeting) to be an enum with only the allowed values _Waiting_ and _Started_
![image](https://github.com/user-attachments/assets/7b7fb61e-7869-4322-ab61-509f36e7f012)

Therefore, to avoid confusion, it was made non nullable here so that it can be used safely from the main repo.