### PR TITLE
Double encode UUID meeting

### DIFF
--- a/Source/ZoomNet/Resources/PastMeetings.cs
+++ b/Source/ZoomNet/Resources/PastMeetings.cs
@@ -3,6 +3,7 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 using ZoomNet.Models;
+using ZoomNet.Utilities;
 
 namespace ZoomNet.Resources
 {
@@ -24,7 +25,7 @@ namespace ZoomNet.Resources
 		public Task<PastMeeting> GetAsync(string meetingId, CancellationToken cancellationToken = default)
 		{
 			return _client
-				.GetAsync($"past_meetings/{meetingId}")
+				.GetAsync($"past_meetings/{Utils.DoubleEncode(meetingId)}")
 				.WithCancellationToken(cancellationToken)
 				.AsObject<PastMeeting>();
 		}
@@ -38,7 +39,7 @@ namespace ZoomNet.Resources
 			}
 
 			return _client
-				.GetAsync($"past_meetings/{meetingId}/participants")
+				.GetAsync($"past_meetings/{Utils.DoubleEncode(meetingId)}/participants")
 				.WithArgument("page_size", recordsPerPage)
 				.WithArgument("next_page_token", pagingToken)
 				.WithCancellationToken(cancellationToken)

--- a/Source/ZoomNet/Utilities/Utils.cs
+++ b/Source/ZoomNet/Utilities/Utils.cs
@@ -1,4 +1,5 @@
 using Microsoft.IO;
+using System.Text.Encodings.Web;
 
 namespace ZoomNet.Utilities
 {
@@ -8,5 +9,7 @@ namespace ZoomNet.Utilities
 	internal static class Utils
 	{
 		public static RecyclableMemoryStreamManager MemoryStreamManager { get; } = new RecyclableMemoryStreamManager();
+
+		public static string DoubleEncode(string value) => UrlEncoder.Default.Encode(UrlEncoder.Default.Encode(value));
 	}
 }

--- a/Source/ZoomNet/ZoomNet.csproj
+++ b/Source/ZoomNet/ZoomNet.csproj
@@ -19,7 +19,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Version>1.0.6</Version>
+    <Version>1.0.7</Version>
     <PackageId>PowerDiary.ZoomNet</PackageId>
     <Authors>Jeremie Desautels;PowerDiary</Authors>
     <Company>PowerDiary</Company>


### PR DESCRIPTION
The main goal of this PR is to double encode the Meeting UUIDs because of these kind of meetings might contain double forward slash. 

This is well know issue that hasn't been fixed since at least 2020.
https://devforum.zoom.us/t/double-encode-meeting-uuids/23729